### PR TITLE
MPC download failure: server returns "500 Internal Server Error"

### DIFF
--- a/getGcc
+++ b/getGcc
@@ -119,7 +119,7 @@ gccFile=$gccPACKAGE.tar.bz2
 
 gmpUrl="http://ftpmirror.gnu.org/gmp/$gmpFile"
 mpfrUrl="http://ftpmirror.gnu.org/mpfr/$mpfrFile"
-mpcUrl="http://www.multiprecision.org/mpc/download/$mpcFile"
+mpcUrl="http://ftpmirror.gnu.org/mpc/$mpcFile"
 gccUrl="http://ftpmirror.gnu.org/gcc/$gccPACKAGE/$gccFile"
 
 getFile ${gmpPACKAGE} ${gmpFile} ${gmpUrl}

--- a/getGcc5
+++ b/getGcc5
@@ -123,7 +123,7 @@ gccFile=$gccPACKAGE.tar.bz2
 
 gmpUrl="http://ftpmirror.gnu.org/gmp/$gmpFile"
 mpfrUrl="http://ftpmirror.gnu.org/mpfr/$mpfrFile"
-mpcUrl="http://www.multiprecision.org/mpc/download/$mpcFile"
+mpcUrl="http://ftpmirror.gnu.org/mpc/$mpcFile"
 gccUrl="http://ftpmirror.gnu.org/gcc/$gccPackageDir/$gccFile"
 
 getFile ${gmpPACKAGE} ${gmpFile} ${gmpUrl}


### PR DESCRIPTION
Thank you so much for sharing your helpful scripts.

I recently noticed mpc download (getGcc & getGcc5) failed, because 
"http://www.multiprecision.org/mpc/download" returns "500 Internal Server Error".

I modified mpcUrl on my local getGcc & getGcc5 just like below:

L:122 on getGcc
- mpcUrl="http://www.multiprecision.org/mpc/download/$mpcFile"
+ mpcUrl="http://ftpmirror.gnu.org/mpc/$mpcFile"

Best,
Senda